### PR TITLE
Download latest stable version of webmachine

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 {deps, [
-  {webmachine, "1.10.*", {git, "git://github.com/webmachine/webmachine", {branch, "develop"}}}
+  {webmachine, "1.10.*", {git, "git://github.com/webmachine/webmachine", {branch, "master"}}}
 ]}.
 
 {relx, [{release, {'{{name}}', "0.1.0"},


### PR DESCRIPTION
Develop brach is an old branch that is not currently updated.