### PR TITLE
Update webmachine dep: branch & protocol

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 {deps, [
-  {webmachine, "1.10.*", {git, "git://github.com/webmachine/webmachine", {branch, "master"}}}
+  {webmachine, "1.10.*", {git, "https://github.com/webmachine/webmachine.git", {branch, "master"}}}
 ]}.
 
 {relx, [{release, {'{{name}}', "0.1.0"},
@@ -19,7 +19,7 @@
 {profiles, [
     {dev, [
         {deps, [
-            {sync, ".*", {git, "git://github.com/rustyio/sync.git", {branch, "master"}}}
+            {sync, ".*", {git, "https://github.com/rustyio/sync.git", {branch, "master"}}}
         ]}
     ]},
     {prod, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 {deps, [
-  {webmachine, "1.10.*", {git, "git://github.com/webmachine/webmachine", {branch, "develop"}}}
+  {webmachine, "1.10.*", {git, "git://github.com/webmachine/webmachine", {branch, "master"}}}
 ]}.
 
 {relx, [{release, {'{{name}}', "0.1.0"},


### PR DESCRIPTION
This builds on #3 and should resolve #4, but also makes the same change as webmachine/webmachine#312 to switch `git://` to `https://`. I will also be opening a webmachine PR shortly to pick up the couple things that are in the develop branch but not in master.